### PR TITLE
edit to founder-fund

### DIFF
--- a/collections/_faqs/07-founder-fund.md
+++ b/collections/_faqs/07-founder-fund.md
@@ -2,6 +2,6 @@
 title: Can you explain the allocations to the founder, operations and Veil Labs?
 ref: founder_fund
 ---
-In order to avoid an ICO and pre-mine, the Veil Project has been pre-funded in excess of one million USD by its founder. As a mechanism to recover this investment, a founder’s reward was established, which tapers and expires over a five-year period.
+In order to avoid an ICO and pre-mine, the Veil Project has been pre-funded in excess of one million USD by its founder. As a mechanism to recover this investment, a founder’s reward was established, which tapers and expires over a five-year period. (Founders reward ended in 2020 read about it here [Technology](/technology/))
 
-The operations budget was established to fund the team (currently over 30 individuals), and the Labs budget was established to fund ongoing research and development in the areas of advanced cryptography and blockchain technologies.
+The operations budget was established to fund the team. The Labs budget was established to fund ongoing research and development in the areas of advanced cryptography and blockchain technologies.


### PR DESCRIPTION
Edit explaining that the founder's reward ended in 2020 and a link to the tech page. Also erasing that the VEIL operation budget serves over 30 people. 