### PR TITLE
Making links open another tab

### DIFF
--- a/en/contact.html
+++ b/en/contact.html
@@ -12,7 +12,7 @@ lead: Getting in touch with Veil is just a click away.
     <div class="container py-12 md:pt-0">
       <h1 class="mb-16 text-2xl md:text-4xl uppercase tracking-wide text-center">Get in touch</h1>
       <div class="max-w-md mx-auto p-10 bg-blue-darker">
-        <form action="https://formspree.io/support@veil-project.com" method="POST">
+        <form action="https://formspree.io/support@veil-project.com" method="POST" target="_blank" rel="noopener noreferrer">
           <p class="mb-6">
             <input type="text" name="name" placeholder="Your name" autofocus class="w-full px-0 rounded-none py-1 text-lg text-white bg-transparent border-b-2 border-teal outline-none focus:border-white">
           </p>

--- a/en/faqs.html
+++ b/en/faqs.html
@@ -5,7 +5,7 @@ ref: faq
 permalink: /faqs/
 title: FAQ
 description: 'View our FAQ about a range of topics such as what makes Veil unique and buying, mining, and staking Veil.'
-lead: 'Getting support in Veil is just a click away. You can visit our <a class="text-white underline" href="https://veil.freshdesk.com/support/home">Support Portal</a>, send us <a class="text-white underline" href="/contact/">an email</a>, or reach out in real-time in <a class="text-white underline" href="https://discord.veil-project.com/">Discord</a>.'
+lead: 'Getting support in Veil is just a click away. You can visit our <a class="text-white underline" href="https://veil.freshdesk.com/support/home" target="_blank" rel="noopener noreferrer">Support Portal</a>, send us <a class="text-white underline" href="/contact/">an email</a>, or reach out in real-time in <a class="text-white underline" href="https://discord.veil-project.com/" target="_blank" rel="noopener noreferrer">Discord</a>.'
 ---
 <div class="border-b border-grey-light">
   {% for faq in site.faqs %}

--- a/en/get-started/bounties-misc.html
+++ b/en/get-started/bounties-misc.html
@@ -17,9 +17,9 @@ description: 'Anyone can earn veil through the Veil Bounty Program.'
   <div class="content">
     <p>Anyone can earn veil through the Veil Bounty Program. A wide variety of tasks will be available ranging from traditional bounty tasks at the beginning, and gradually expanding to high reward contests, development bounties, and adopting Veil as a merchant or service as the program expands.</p>
     <div class="content text-center">
-      <div><a href="https://bitcointalk.org/index.php?topic=5125073">Veil Bounty Program Thread</a></div>
-      <div><a href="https://t.me/VEILBounty">Veil Bounty Program Telegram Group</a></div>
-      <div><a href="https://discord.gg/EfFUbEy">Veil Developer Bounty Discord</a></div>
+      <div><a href="https://bitcointalk.org/index.php?topic=5125073" target="_blank" rel="noopener noreferrer">Veil Bounty Program Thread</a></div>
+      <div><a href="https://t.me/VEILBounty" target="_blank" rel="noopener noreferrer">Veil Bounty Program Telegram Group</a></div>
+      <div><a href="https://discord.gg/EfFUbEy" target="_blank" rel="noopener noreferrer">Veil Developer Bounty Discord</a></div>
     </div>
 
 

--- a/en/get-started/bounties.html
+++ b/en/get-started/bounties.html
@@ -30,8 +30,8 @@ description: 'Anyone can earn veil through the Veil Bounty Program.'
     </p>
     <ul>
       <li class="mb-3"><strong>Availability</strong> — Bounties are available only on issues tagged <code class="inline-block bg-grey-lighter px-2 pb-1 font-bold rounded-sm">Bounty: Open</code></li>
-      <li class="mb-3"><strong>Application</strong> — If you are interested in working on a bounty issue, you should enter the <a href="https://discord.gg/EfFUbEy">Veil Development Discord</a>, and request that the issue is reserved for you.</li>
-      <li class="mb-3"><strong>Interaction</strong> — As you work on the task, you can post questions and feedback as notes on the issue. In addition, interactive discussion with the Veil development team is available through the dedicated <a href="https://discord.gg/EfFUbEy">Veil Development Discord</a></li>
+      <li class="mb-3"><strong>Application</strong> — If you are interested in working on a bounty issue, you should enter the <a href="https://discord.gg/EfFUbEy" target="_blank" rel="noopener noreferrer">Veil Development Discord</a>, and request that the issue is reserved for you.</li>
+      <li class="mb-3"><strong>Interaction</strong> — As you work on the task, you can post questions and feedback as notes on the issue. In addition, interactive discussion with the Veil development team is available through the dedicated <a href="https://discord.gg/EfFUbEy" target="_blank" rel="noopener noreferrer">Veil Development Discord</a></li>
       <li class="mb-3"><strong>Completion & payment</strong> — Once a task has been successfully completed, you will be paid the bounty in veil.</li>
     </ul>
     <h3>2. Currently Open Development Bounties</h3>
@@ -42,7 +42,7 @@ description: 'Anyone can earn veil through the Veil Bounty Program.'
 <div class="content">
 <h3>3. Veil Developer Team Structure</h3>
     <p>
-      The follow list identifies the structure in place for Veil Developers. Those interested should reach out to us in the #community-bounty channel of the <a href="http://dev-discord.veil-project.com">Veil Development Discord</a>.
+      The follow list identifies the structure in place for Veil Developers. Those interested should reach out to us in the #community-bounty channel of the <a href="http://dev-discord.veil-project.com" target="_blank" rel="noopener noreferrer">Veil Development Discord</a>.
     </p>
     <ul>
       <li class="mb-3"><strong>No title</strong> — Any person is able to earn up to 2,000 Veil of bounty per month.</li>

--- a/en/get-started/exchanges.html
+++ b/en/get-started/exchanges.html
@@ -14,8 +14,8 @@ description: 'Veil Project specs—Veil blockchain technology specifications. Vi
   </p>
 
 <ul>
-<li><a href="https://tradeogre.com/exchange/BTC-VEIL">TradeOgre</a> - the most liquidity, all genuine. Cheap and fast withdrawals</li>
-<li><a href="https://www.probit.com/">Probit</a> - an established Korean exchange, still with sporadic Veil volume. Korean regulations make continued listing uncertain. Currently Veil withdrawals on Probit exchange cost 0.2 Veil. Deposits <em>are available</em> and confirm after 30 minutes. Current wallet version is <em>to be confirmed.</em></li>
+<li><a href="https://tradeogre.com/exchange/BTC-VEIL" target="_blank" rel="noopener noreferrer">TradeOgre</a> - the most liquidity, all genuine. Cheap and fast withdrawals</li>
+<li><a href="https://www.probit.com/" target="_blank" rel="noopener noreferrer">Probit</a> - an established Korean exchange, still with sporadic Veil volume. Korean regulations make continued listing uncertain. Currently Veil withdrawals on Probit exchange cost 0.2 Veil. Deposits <em>are available</em> and confirm after 30 minutes. Current wallet version is <em>to be confirmed.</em></li>
 </ul>
 <p>———Exchanges pending addition———</p>
 <ul>
@@ -31,7 +31,7 @@ description: 'Veil Project specs—Veil blockchain technology specifications. Vi
 </ul>
 
   <p>
-  <strong>Note</strong> — The exchanges currently accept deposits in Basecoin only, and the Veil wallet currently will only send to stealth addresses on the Send screen. Sending Basecoin from the wallet can be done through the Console, as described <a href="https://veil.freshdesk.com/support/solutions/articles/43000474291-different-methods-sending-coins-from-debug-console-">in this support article</a>.
+  <strong>Note</strong> — The exchanges currently accept deposits in Basecoin only, and the Veil wallet currently will only send to stealth addresses on the Send screen. Sending Basecoin from the wallet can be done through the Console, as described <a href="https://veil.freshdesk.com/support/solutions/articles/43000474291-different-methods-sending-coins-from-debug-console-" target="_blank" rel="noopener noreferrer">in this support article</a>.
   </p>
 
   <p>It is technically possible for the exchanges to allow withdrawals to Stealth (sv) addresses, and the Veil wallet in 2022 was improved to enable users to receive stealth Veil while the wallet is still locked, and to have the amounts appear automatically when unlocking. In 2019 an exchange briefly was letting people withdraw stealth amounts, but support load increased as customers needed to unlock AND go through a procedure in order to see their incoming amounts. This complication has been removed, so exchanges are welcome to try stealth transactions again.</p>

--- a/en/get-started/mining.html
+++ b/en/get-started/mining.html
@@ -14,32 +14,32 @@ description: 'Veil Project specs—Veil blockchain technology specifications. Vi
   </p>
   <h2>Block explorers</h2>
   <ul>
-    <li>Mainnet — <a href="https://explorer.veil-project.com/">https://explorer.veil-project.com/</a></li>
-    <li>Testnet — <a href="https://testnet.veil-project.com/">https://testnet.veil-project.com/</a></li>
+    <li><a href="https://explorer.veil-project.com/" target="_blank" rel="noopener noreferrer">Mainnet</a></li>
+    <li><a href="https://testnet.veil-project.com/" target="_blank" rel="noopener noreferrer">Testnet</a></li>
 
 
   </ul>
 
   <h2>Mining software</h2>
   <ul>
-    <li><a href="https://github.com/trexminer/T-Rex/releases">T-Rex (NVIDIA)</a></li>
-    <li><a href="https://github.com/andru-kun/wildrig-multi/releases/">Wildrig (AMD)</a></li>
-    <li><a href="https://github.com/TrailingStop/TT-Miner-release">TT-Miner (NVIDIA)</a></li>
-    <li><a href="https://github.com/us77ipis/xmrig-veil">Xmrig (CPU)</a></li>
+    <li><a href="https://github.com/trexminer/T-Rex/releases" target="_blank" rel="noopener noreferrer">T-Rex (NVIDIA)</a></li>
+    <li><a href="https://github.com/andru-kun/wildrig-multi/releases/" target="_blank" rel="noopener noreferrer">Wildrig (AMD)</a></li>
+    <li><a href="https://github.com/TrailingStop/TT-Miner-release" target="_blank" rel="noopener noreferrer">TT-Miner (NVIDIA)</a></li>
+    <li><a href="https://github.com/us77ipis/xmrig-veil" target="_blank" rel="noopener noreferrer">Xmrig (CPU)</a></li>
   </ul>
 
   <h2>Mining pools</h2>
   <ul>
-    <li><a href="https://fastpool.xyz/veil-rx/">FastPool (RandomX)</a></li>
+    <li><a href="https://fastpool.xyz/veil-rx/" target="_blank" rel="noopener noreferrer">FastPool (RandomX)</a></li>
   </ul>
 
   <h2>Stratum proxy for solo mining</h2>
-  <p>To enable solo mining with third party software (such as the T-Rex miner and Xmrig) running the ProgPow or RandomX algorithm without a pool connection, try this stratum proxy, <a href="https://github.com/us77ipis/veil-node-stratum-proxy">veil node stratum proxy</a></p>
+  <p>To enable solo mining with third party software (such as the T-Rex miner and Xmrig) running the ProgPow or RandomX algorithm without a pool connection, try this stratum proxy, <a href="https://github.com/us77ipis/veil-node-stratum-proxy" target="_blank" rel="noopener noreferrer">veil node stratum proxy</a></p>
 
   <h2>Profitability calculator</h2>
   <ul>
-    <li><a href="https://whattomine.com/coins/286-veil-progpow">whattomine</a></li>
-    <li><a href="https://minerstat.com/coin/VEIL_progpow">Minerstat</a></li>
+    <li><a href="https://whattomine.com/coins/286-veil-progpow" target="_blank" rel="noopener noreferrer">whattomine</a></li>
+    <li><a href="https://minerstat.com/coin/VEIL_progpow" target="_blank" rel="noopener noreferrer">Minerstat</a></li>
   </ul>
 
 </div>

--- a/en/get-started/wallets.html
+++ b/en/get-started/wallets.html
@@ -10,21 +10,21 @@ description: 'Veil Project specs—Veil blockchain technology specifications. Vi
 
 <div class="content mb-12">
 <p><strong>Current version</strong> is <strong>1.4.0.0</strong> a <strong>mandatory upgrade</strong>. 
-  The previous mandatory wallet released was version 1.3.0.0. Wallet issues are tracked at <a href="https://github.com/Veil-Project/veil/issues">GitHub Issues List</a><!--, and a summary of the most important maintained in our <strong><a href="/changelog/">changelog</a></strong> -->. Daily blockchain <strong>snapshots</strong> are available for download at the <strong><a href="https://veil.tools">Veil Tools</a></strong> website</p>
+  The previous mandatory wallet released was version 1.3.0.0. Wallet issues are tracked at <a href="https://github.com/Veil-Project/veil/issues" target="_blank" rel="noopener noreferrer">GitHub Issues List</a><!--, and a summary of the most important maintained in our <strong><a href="/changelog/">changelog</a></strong> -->. Daily blockchain <strong>snapshots</strong> are available for download at the <strong><a href="https://veil.tools">Veil Tools</a></strong> website</p>
     
 </div>
 
 <div class="mb-12 md:mb-16 leading-tight text-sm">
   <div class="flex flex-col md:flex-row text-center">
-    <a href="https://github.com/Veil-Project/veil/releases" class="flex-1 p-8 pb-6 flex flex-col items-center bg-blue-lighter rounded text-black hover:text-blue">
+    <a href="https://github.com/Veil-Project/veil/releases" target="_blank" rel="noopener noreferrer" class="flex-1 p-8 pb-6 flex flex-col items-center bg-blue-lighter rounded text-black hover:text-blue">
       <img src="/dist/img/platforms/windows.svg" class="w-16 h-16 mb-4">
       <strong class="text-md font-medium">Windows</strong>
     </a>
-    <a href="https://github.com/Veil-Project/veil/releases" class="flex-1 p-8 pb-6 flex flex-col items-center bg-blue-lighter rounded mt-1 md:mt-0 md:ml-1 text-black hover:text-blue">
+    <a href="https://github.com/Veil-Project/veil/releases" target="_blank" rel="noopener noreferrer" class="flex-1 p-8 pb-6 flex flex-col items-center bg-blue-lighter rounded mt-1 md:mt-0 md:ml-1 text-black hover:text-blue">
       <img src="/dist/img/platforms/linux.svg" class="w-16 h-16 mb-4">
       <strong class="text-md font-medium">Linux</strong>
     </a>
-    <a href="https://github.com/Veil-Project/veil/releases" class="flex-1 p-8 pb-6 flex flex-col items-center bg-blue-lighter rounded mt-1 md:mt-0 md:ml-1 text-black hover:text-blue">
+    <a href="https://github.com/Veil-Project/veil/releases" target="_blank" rel="noopener noreferrer" class="flex-1 p-8 pb-6 flex flex-col items-center bg-blue-lighter rounded mt-1 md:mt-0 md:ml-1 text-black hover:text-blue">
       <img src="/dist/img/platforms/macos.svg" class="w-16 h-16 mb-4">
       <strong class="text-md font-medium">macOS</strong>
     </a>


### PR DESCRIPTION
This Pr makes it so that when the links on the website are click they open new page instead of leaving the website. This is to encourage users to easily click right back to where they where on the website without the back button on the browser. 

Also made an edit to the Mainnet and Testnet links to not have the actual link but a link that says *Mainnet* and *Testnet*

Ready for QA @seanPhill 