### PR TITLE
Github Pages is showing "-->" at the top

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,7 +2,7 @@
 {% assign home = pages[0] %}
 
 <div class="VeilNav VeilNav--sm md:hidden fixed z-50 pin-t pin-x" up-nav>
-  <!-- <div data-price up-keep up-id="marketprice1" class="flex-none p-4 font-medium text-sm"><span class="text-white opacity-25">Loading…</span></div> -->
+  <!-- <div data-price up-keep up-id="marketprice1" class="flex-none p-4 font-medium text-sm"><span class="text-white opacity-25">Loading...</span></div> -->
 
   <a up-dash href="{{ home.url }}" class="VeilNav-logo flex flex-col items-center justify-center">
     <span class="VeilNav-logo-icon"><img src="/dist/img/logo-icon.png" class="w-16" alt=""></span>
@@ -41,7 +41,7 @@
     <a up-dash class="block text-lg text-white" href="/bounties/">Bounties</a>
     <a class="block text-lg text-white" href="https://explorer.veil-project.com" target="_blank" rel="noopener noreferrer">Explorer</a>
     <a class="block text-lg text-white" href="https://veil.tools" target="_blank" rel="noopener noreferrer">Tools</a>
-    <!--<a class="block text-lg text-white" href="https://veil-stats.com" target="_blank" rel="noopener noreferrer">Network Stats</a> Until veil-stats comes back or a new comes online -->
+    <!-- <a class="block text-lg text-white" href="https://veil-stats.com" target="_blank" rel="noopener noreferrer">Network Stats</a> Until veil-stats comes back or a new comes online -->
 
 
     <span class="block mb-1 mt-8 uppercase tracking-wide font-medium text-teal text-sm">
@@ -102,7 +102,7 @@
           <a up-dash class="hover:text-blue" href="/bounties/">Bounties</a>
           <a class="hover:text-blue" href="https://explorer.veil-project.com" target="_blank" rel="noopener noreferrer">Explorer</a>
           <a class="hover:text-blue" href="https://veil.tools" target="_blank" rel="noopener noreferrer">Tools</a>
-          <!--<a class="hover:text-blue" href="https://veil-stats.com" target="_blank" rel="noopener noreferrer">Network Stats</a> until back online -->
+          <!-- <a class="hover:text-blue" href="https://veil-stats.com" target="_blank" rel="noopener noreferrer">Network Stats</a> until back online -->
 
         </div>
       </div>
@@ -118,10 +118,10 @@
       </div>
     </nav>
     <!-- 
-<div class="px-8">
-      <div data-price up-keep up-id="marketprice2"><span class="text-white opacity-25">Loading…</span></div>
-    </div>
- -->
+      <div class="px-8">
+            <div data-price up-keep up-id="marketprice2"><span class="text-white opacity-25">Loading...</span></div>
+      </div>
+    -->
   </div>
 </div>
 

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -22,10 +22,10 @@ layout: base
 
       <p class="mt-8 flex flex-col md:mt-12 md:flex-row items-start md:items-center">
         <!-- 
-<a href="/video/" up-history="false" up-modal=".video" class="relative inline-block leading-none text-center pt-4 pb-3 pr-6 pl-12 rounded-full border border-teal bg-teal hover:bg-white hover:border-white text-blue-dark text-sm font-medium uppercase tracking-wide">
+          <a href="/video/" up-history="false" up-modal=".video" class="relative inline-block leading-none text-center pt-4 pb-3 pr-6 pl-12 rounded-full border border-teal bg-teal hover:bg-white hover:border-white text-blue-dark text-sm font-medium uppercase tracking-wide">
           {% include icon.html name="video" class="w-5 h-5 absolute pin-l pin-t m-3 ml-4" %} Watch the Video
-        </a>
- -->
+          </a>
+         -->
         <a href="#overview" class="relative inline-block leading-none text-center pt-4 pb-3 px-6 mt-4 md:mt-0 md:ml-4 rounded-full border-2 border-teal hover:border-white text-teal hover:text-white text-sm font-medium uppercase tracking-wide">
           Learn more
         </a>
@@ -44,14 +44,14 @@ layout: base
 {% endcapture %}
 {% include header.html content=header %}
 <!-- 
-<div class="pt-4 pb-3 flex items-center bg-blue-dark">
-  <div class="container text-center">
-    <a href="/blog/new-veil-protocol/" class="inline-block leading-tight font-medium text-white hover:text-teal text-sm">
-      Important notice regarding Zerocoin functionality
-      <span>{% include icon.html name="chevron-right" class="w-2 h-2" %}</span>
-    </a>
+  <div class="pt-4 pb-3 flex items-center bg-blue-dark">
+    <div class="container text-center">
+      <a href="/blog/new-veil-protocol/" class="inline-block leading-tight font-medium text-white hover:text-teal text-sm">
+        Important notice regarding Zerocoin functionality
+        <span>{% include icon.html name="chevron-right" class="w-2 h-2" %}</span>
+      </a>
+    </div>
   </div>
-</div>
  -->
 <main class="flex-1 w-full overflow-x-hidden bg-blue-darker text-white">
   {{ content }}

--- a/en/about.html
+++ b/en/about.html
@@ -22,15 +22,15 @@ description: 'The Veil Project was conceived in 2018, motivated by the need for 
         Veil implemented a self-sustaining mechanism, encoded into the network, providing funding for ongoing operations, marketing, partnerships, bounties and other activities required of successful initiatives.
       </p>
       <!--
-      <p>
-        Veil Labs has already attracted interest from some of the leading academic institutions in the world, and will help ensure that the Veil Project remains at the forefront of crypto privacy.
-      </p>
-      <p>
-        <a href="/veil-labs/" class="font-medium">
-          More about Veil Labs
-          {% include icon.html name="chevron-right" class="h-2 w-2" %}
-        </a>
-      </p>
+        <p>
+          Veil Labs has already attracted interest from some of the leading academic institutions in the world, and will help ensure that the Veil Project remains at the forefront of crypto privacy.
+        </p>
+        <p>
+          <a href="/veil-labs/" class="font-medium">
+            More about Veil Labs
+            {% include icon.html name="chevron-right" class="h-2 w-2" %}
+          </a>
+        </p>
       -->
     </div>
     <div class="flex-none md:w-1/4">

--- a/en/get-started/wallets.html
+++ b/en/get-started/wallets.html
@@ -10,7 +10,7 @@ description: 'Veil Project specs—Veil blockchain technology specifications. Vi
 
 <div class="content mb-12">
 <p><strong>Veil Core wallet current version</strong> is <strong>1.4.1.0</strong> a <strong>non-mandatory upgrade</strong>. 
-  The previous mandatory wallet released was version 1.4.0.0. Wallet issues are tracked at <a href="https://github.com/Veil-Project/veil/issues" target="_blank" rel="noopener noreferrer">GitHub Issues List</a><!--, and a summary of the most important maintained in our <strong><a href="/changelog/">changelog</a></strong> -->. Daily blockchain <strong>snapshots</strong> are available for download at the <strong><a href="https://veil.tools">Veil Tools</a></strong> website</p>
+  The previous mandatory wallet released was version 1.4.0.0. Wallet issues are tracked at <a href="https://github.com/Veil-Project/veil/issues" target="_blank" rel="noopener noreferrer">GitHub Issues List</a> <!-- , and a summary of the most important maintained in our <strong><a href="/changelog/">changelog</a></strong> -->. Daily blockchain <strong>snapshots</strong> are available for download at the <strong><a href="https://veil.tools">Veil Tools</a></strong> website</p>
 
   <div class="mb-12 md:mb-16 leading-tight text-sm">
     <div class="flex flex-col md:flex-row text-center">


### PR DESCRIPTION
An end comment section tag ` -->` is showing at the top of the website if you are scrolled all the way to the top. On mobile if you scroll down and then up it doesn't show anymore. This is not happening in the locally Jekyll, at least while using `bundle exec jekyll serve`.

As there is not actually an unmatched end quote ` -->` I have simply checked indentation, and made sure that the start comment ` <!--` has whitespace on each side of it. No changes are visible locally, nor should they be, except hoping that Github Pages no longer displays ` -->` at the top of the website.