### PR TITLE
fix: mobile alignment for get-started icons

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -96,28 +96,28 @@ lead: 'Veil is a privacy first cryptocurrency designed for private transactions,
 
   <div class="container">
     <div class="flex flex-col md:flex-row md:text-center">
-      <a up-dash href="/get-started/" class="flex-1 text-white hover:text-teal flex md:flex-col items-center justify-end">
+      <a up-dash href="/get-started/" class="flex-1 text-white hover:text-teal flex flex-col items-center md:justify-end">
         <img src="/dist/img/get-started/wallet.svg" class="w-20 h-20 md:w-32 md:h-32" alt="">
         <div class="mt-4 font-medium">Get the wallet</div>
       </a>
 
       <div class="flex-none h-px md:h-auto md:w-px bg-blue-light opacity-25 my-6 md:mx-8"></div>
 
-      <a up-dash href="/mining/" class="flex-1 text-white hover:text-teal flex md:flex-col items-center justify-end">
+      <a up-dash href="/mining/" class="flex-1 text-white hover:text-teal flex flex-col items-center md:justify-end">
         <img src="/dist/img/get-started/mine.svg" class="w-20 h-20 md:w-32 md:h-32" alt="">
         <div class="mt-4 font-medium">Mine Veil</div>
       </a>
 
       <div class="flex-none h-px md:h-auto md:w-px bg-blue-light opacity-25 my-6 md:mx-8"></div>
 
-      <a up-dash href="/exchanges/" class="flex-1 text-white hover:text-teal flex md:flex-col items-center justify-end">
+      <a up-dash href="/exchanges/" class="flex-1 text-white hover:text-teal flex flex-col items-center md:justify-end">
         <img src="/dist/img/get-started/exchange.svg" class="w-20 h-20 md:w-32 md:h-32" alt="">
         <div class="mt-4 font-medium">Buy Veil</div>
       </a>
 
       <div class="flex-none h-px md:h-auto md:w-px bg-blue-light opacity-25 my-6 md:mx-8"></div>
 
-      <a up-dash href="/bounties/" class="flex-1 text-white hover:text-teal flex md:flex-col items-center justify-end">
+      <a up-dash href="/bounties/" class="flex-1 text-white hover:text-teal flex flex-col items-center md:justify-end">
         <img src="/dist/img/get-started/bounty.svg" class="w-20 h-20 md:w-32 md:h-32" alt="">
         <div class="mt-4 font-medium">Contribute</div>
       </a>


### PR DESCRIPTION
Fixes #103 — get-started icons were left-aligned on mobile due to justify-end applying without flex-col. Changed to flex flex-col items-center md:justify-end so icons stack and center on mobile while maintaining desktop layout.